### PR TITLE
use fast-render and remove jquery-ui theme

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -31,4 +31,5 @@ pauloborges:repl
 aldeed:autoform
 aldeed:collection2
 oauth
+meteorhacks:fast-render
 

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -50,6 +50,7 @@ localstorage@1.0.0
 logging@1.0.3
 meteor-platform@1.1.1
 meteor@1.1.1
+meteorhacks:fast-render@1.1.2
 minifiers@1.1.0
 minimongo@1.0.3
 mobile-status-bar@1.0.0

--- a/client/main.html
+++ b/client/main.html
@@ -28,7 +28,7 @@
   <link href='//api.tiles.mapbox.com/mapbox.js/v1.6.4/mapbox.css' rel='stylesheet' />
   <script src='//api.tiles.mapbox.com/mapbox.js/v1.6.4/mapbox.js'></script>
 
-  <script src="//code.jquery.com/ui/1.11.0/jquery-ui.js"></script>
+  <script src="//code.jquery.com/ui/1.11.0/jquery-ui.min.js"></script>
 
   <link rel="shortcut icon" href="/img/favicons/favicon.ico">
   <link rel="apple-touch-icon" sizes="57x57" href="/img/favicons/apple-touch-icon-57x57.png">

--- a/client/main.html
+++ b/client/main.html
@@ -28,7 +28,6 @@
   <link href='//api.tiles.mapbox.com/mapbox.js/v1.6.4/mapbox.css' rel='stylesheet' />
   <script src='//api.tiles.mapbox.com/mapbox.js/v1.6.4/mapbox.js'></script>
 
-  <link rel="stylesheet" href="//code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css">
   <script src="//code.jquery.com/ui/1.11.0/jquery-ui.js"></script>
 
   <link rel="shortcut icon" href="/img/favicons/favicon.ico">


### PR DESCRIPTION
This seems to improve page load performance a little bit. I also tried to remove the JQuery-UI-library, but it seems the vertical "news-carousel" does use it to hide it.

There are still many more things we can do to improve performance, I discussed a little bit about this yesterday with Jarno.