### PR TITLE
also convert pictures not containing _normal.ext suffix #99

### DIFF
--- a/web/packages/account/account/servicedata.jsdoc
+++ b/web/packages/account/account/servicedata.jsdoc
@@ -131,7 +131,7 @@ Account.serviceData.unify = function(data, service) {
 
       if (!data.default_profile_image && data.profile_image_url) {
         // remove '_normal' from url to get original size and use a size of 200x200
-        data.picture = data.profile_image_url.replace(/_normal(.{0,5})$/, '_200x200$1');
+        data.picture = data.profile_image_url.replace(/(_normal)?(.{0,5})$/, '_200x200$2');
       }
       var urls = Object.property(data, 'entities.url.urls');
       if (urls && urls[0])

--- a/web/packages/account/account/servicedata.jsdoc
+++ b/web/packages/account/account/servicedata.jsdoc
@@ -131,7 +131,7 @@ Account.serviceData.unify = function(data, service) {
 
       if (!data.default_profile_image && data.profile_image_url) {
         // remove '_normal' from url to get original size and use a size of 200x200
-        data.picture = data.profile_image_url.replace(/(_normal)?(.{0,5})$/, '_200x200$2');
+        data.picture = data.profile_image_url.replace(/(_normal)?(\..{0,4})$/, '_200x200$2');
       }
       var urls = Object.property(data, 'entities.url.urls');
       if (urls && urls[0])

--- a/web/packages/account/account/userdata.jsdoc
+++ b/web/packages/account/account/userdata.jsdoc
@@ -264,7 +264,7 @@ Account.userData.updateProfilePictures = function() {
   }}).fetch();
 
   // update twitter images if needed
-  async.forEachLimit(users, 100000, function(user, cb) {
+  async.forEachLimit(users, 4, function(user, cb) {
     var serviceName = "twitter";
     var image = user.profile.socialPicture[serviceName];
     var isCurrentPicture = image === user.profile.picture;


### PR DESCRIPTION
This makes the _normal part for the match optional. Also restore the foreach limit back to 4 (mistake from previous PR).